### PR TITLE
[#154321830] Add command line parameters to support parallel iOS Safa…

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -74,6 +74,24 @@ const args = [
     help: '(Android-only) port to use on device to talk to Appium',
   }],
 
+  [['-wdap', '--web-driver-agent-port'], {
+    defaultValue: 8100,
+    dest: 'wdaPort',
+    required: false,
+    type: 'int',
+    example: '8101',
+    help: '(iOS-only) port for WebDriverAgent to use',
+  }],
+
+  [['-rdp', '--remote-debugger-port'], {
+    defaultValue: 27753,
+    dest: 'remoteDebuggerPort',
+    required: false,
+    type: 'int',
+    example: '27754',
+    help: 'port for WebKit remote debugger to use',
+  }],
+
   [['-r', '--backend-retries'], {
     defaultValue: 3,
     dest: 'backendRetries',


### PR DESCRIPTION
…ri testing.

- `--remote-debugger-port` (default 27753)
- `--web-driver-agent-port` (default 8100)

These parameters get put in an object called `opts` or `args` which gets passed around pretty much everywhere.